### PR TITLE
Add global to Johnny Five Install

### DIFF
--- a/pages/lab000.md
+++ b/pages/lab000.md
@@ -93,12 +93,12 @@ Johnny-Five is an open source JavaScript framework that provides a simple object
 Once you have Node.js installed, install [Johnny-Five][11] using NPM.
 On Windows, open the Node.js command prompt and type the following:
 <pre>
-npm install johnny-five
+npm install -g johnny-five
 </pre>
 
 On Mac OS X open Terminal and type the following:
 <pre>
-sudo npm install johnny-five
+sudo npm install -g johnny-five
 </pre>
 
 ## Install Nitrogen


### PR DESCRIPTION
Johnny Five needs to be installed globally for this to work well, so this is updating the doc to reflect that.
