### PR TITLE
We're at Defcon, let's use HTTPS

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -21,8 +21,8 @@ description: "»ThingLabs.io empowers you to build connected Things."
 
 # This URL is the main adresse. Don't include a slash at the end.
 #
-url: "http://thinglabsio.github.io"
-baseurl: "http://thinglabsio.github.io"
+url: "https://thinglabsio.github.io"
+baseurl: "https://thinglabsio.github.io"
 
 # This is for the editing function in _/includes/improve_content.html
 # Leave it empty if your site is not on GitHub/GitHub Pages
@@ -34,7 +34,7 @@ improve_content: https://github.com/ThingLabsIo/edit/gh-pages
 # Example: <img src="{{ site.urlimg }}/{{ post.image.title }}">
 # Markdown-Example for posts ![Image Text]({{ site.urlimg }}/image.jpg)
 #
-urlimg: "http://thinglabsio.github.io/images/"
+urlimg: "https://thinglabsio.github.io/images/"
 
 
 # Logo size is 600x80 pixels

--- a/_data/socialmedia.yml
+++ b/_data/socialmedia.yml
@@ -1,9 +1,9 @@
 - name: Twitter
-  url: http://twitter.com/thinglabsio
+  url: https://twitter.com/thinglabsio
   class: icon-twitter
   title: "ThingLabs.io on Twitter"
 
 - name: GitHub
-  url: http://github.com/ThingLabsIo
+  url: https://github.com/ThingLabsIo
   class: icon-github
   title: "ThingLabs.io on GitHub"

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -24,7 +24,7 @@
   </script>
 
   <noscript>
-    <link href='http://fonts.googleapis.com/css?family=Lato:400,700,400italic%7cVolkhov' rel='stylesheet' type='text/css'>
+    <link href='https://fonts.googleapis.com/css?family=Lato:400,700,400italic%7cVolkhov' rel='stylesheet' type='text/css'>
   </noscript>
 
   {% if site.google_site_verification %}<meta name="google-site-verification" content="{{ site.google_site_verification}}" />{% endif %}


### PR DESCRIPTION
The page currently looks pretty horrible if somebody tries to access it using HTTPS (which many browsers will do by default). This change ensures that the page always looks like it's supposed to.

<img width="857" alt="screen shot 2015-08-07 at 3 04 48 pm" src="https://cloud.githubusercontent.com/assets/1426799/9146927/d2559a5e-3d15-11e5-9ea3-da0550a7b795.png">
